### PR TITLE
Add OAuth PKCE auth flow

### DIFF
--- a/.env
+++ b/.env
@@ -8,5 +8,8 @@ PUBLIC_HASURA_WEB_SOCKET_URL=ws://localhost:8080/v1/graphql
 PUBLIC_AUTH_SSO_ENABLED=false
 PUBLIC_TIME_PLUGIN_ENABLED=false
 PUBLIC_COMMAND_EXPANSION_MODE=typescript
+# Identity provider base URL used for Authorization Code Flow with PKCE
+PUBLIC_IDENTITY_PROVIDER_URL=http://localhost:7777
+PUBLIC_OIDC_CLIENT_ID=aerie-ui
 # VITE_HOST=localhost.jpl.nasa.gov
 # VITE_HTTPS=true

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -14,3 +14,5 @@ This document provides detailed information about environment variables for Aeri
 | `PUBLIC_HASURA_SERVER_URL`       | Url of Hasura as called from the server (i.e. Node.js container)                                              | `string` | http://localhost:8080/v1/graphql |
 | `PUBLIC_HASURA_WEB_SOCKET_URL`   | Url of Hasura called to establish a web-socket connection from the client                                     | `string` | ws://localhost:8080/v1/graphql   |
 | `PUBLIC_TIME_PLUGIN_ENABLED`     | Whether the client should load a user-supplied `time-plugin.js` plugin from the `static/resources` directory. | `string` | false                            |
+| `PUBLIC_IDENTITY_PROVIDER_URL`   | Base URL of the OpenID Connect identity provider used for PKCE authentication. | `string` | http://localhost:7777           |
+| `PUBLIC_OIDC_CLIENT_ID`          | Client identifier registered with the identity provider. | `string` | aerie-ui                        |

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -2,11 +2,10 @@ import { base } from '$app/paths';
 import { env } from '$env/dynamic/public';
 import type { Handle } from '@sveltejs/kit';
 import { parse, type CookieSerializeOptions } from 'cookie';
-import { jwtDecode } from 'jwt-decode';
-import type { BaseUser, ParsedUserToken, User } from './types/app';
+import type { BaseUser, User } from './types/app';
 import type { ReqValidateSSOResponse } from './types/auth';
-import effects from './utilities/effects';
 import { reqGatewayForwardCookies } from './utilities/requests';
+import { computeRolesFromCookies, computeRolesFromJWT } from './utilities/auth';
 
 export const handle: Handle = async ({ event, resolve }) => {
   try {
@@ -52,6 +51,30 @@ const handleJWTAuth: Handle = async ({ event, resolve }) => {
 };
 
 const handleSSOAuth: Handle = async ({ event, resolve }) => {
+  // if an identity provider is specified use the Authorization Code Flow
+  if (env.PUBLIC_IDENTITY_PROVIDER_URL) {
+    const cookieHeader = event.request.headers.get('cookie') ?? '';
+    const cookies = parse(cookieHeader);
+    const { activeRole: activeRoleCookie = null, user: userCookie } = cookies;
+
+    if (userCookie) {
+      const user = await computeRolesFromCookies(userCookie, activeRoleCookie);
+      if (user) {
+        event.locals.user = user;
+        return await resolve(event);
+      }
+    }
+
+    if (event.url.pathname.startsWith('/auth/callback')) {
+      return await resolve(event);
+    }
+
+    return new Response(null, {
+      headers: { location: `${base}/auth/authorize` },
+      status: 307,
+    });
+  }
+
   const cookieHeader = event.request.headers.get('cookie') ?? '';
   const cookies = parse(cookieHeader);
   const { activeRole: activeRoleCookie = null } = cookies;
@@ -108,45 +131,3 @@ const handleSSOAuth: Handle = async ({ event, resolve }) => {
   return await resolve(event);
 };
 
-async function computeRolesFromCookies(
-  userCookie: string | null,
-  activeRoleCookie: string | null,
-): Promise<User | null> {
-  const userBuffer = Buffer.from(userCookie ?? '', 'base64');
-  const userStr = userBuffer.toString('utf-8');
-
-  try {
-    const baseUser: BaseUser = JSON.parse(userStr);
-    return computeRolesFromJWT(baseUser, activeRoleCookie);
-  } catch {
-    return null;
-  }
-}
-
-async function computeRolesFromJWT(baseUser: BaseUser, activeRole: string | null): Promise<User | null> {
-  const { success } = await effects.session(baseUser);
-  if (!success) {
-    return null;
-  }
-
-  const decodedToken: ParsedUserToken = jwtDecode(baseUser.token);
-
-  const allowedRoles = decodedToken['https://hasura.io/jwt/claims']['x-hasura-allowed-roles'];
-  const defaultRole = decodedToken['https://hasura.io/jwt/claims']['x-hasura-default-role'];
-
-  const user: User = {
-    ...baseUser,
-    activeRole: activeRole ?? defaultRole,
-    allowedRoles,
-    defaultRole,
-    permissibleQueries: null,
-    rolePermissions: null,
-  };
-  const permissibleQueries = await effects.getUserQueries(user);
-  const rolePermissions = await effects.getRolePermissions(user);
-  return {
-    ...user,
-    permissibleQueries,
-    rolePermissions,
-  };
-}

--- a/src/routes/auth/authorize/+server.ts
+++ b/src/routes/auth/authorize/+server.ts
@@ -1,0 +1,34 @@
+import { base } from '$app/paths';
+import { env as privateEnv } from '$env/dynamic/private';
+import { env } from '$env/dynamic/public';
+import type { RequestHandler } from '@sveltejs/kit';
+import { redirect } from '@sveltejs/kit';
+import type { CookieSerializeOptions } from 'cookie';
+import { generateCodeVerifier, generateCodeChallenge } from '../../../utilities/auth';
+
+export const GET: RequestHandler = async ({ cookies }) => {
+  const verifier = generateCodeVerifier();
+  const challenge = generateCodeChallenge(verifier);
+
+  const cookieOpts: CookieSerializeOptions & { path: string } = {
+    httpOnly: true,
+    path: `${base}/`,
+    sameSite: 'lax',
+  };
+
+  cookies.set('pkceVerifier', verifier, cookieOpts);
+
+  const redirectUri = `${privateEnv.ORIGIN}${base}/auth/callback`;
+  const authorizationEndpoint = `${env.PUBLIC_IDENTITY_PROVIDER_URL}/authorize`;
+
+  const params = new URLSearchParams({
+    response_type: 'code',
+    client_id: env.PUBLIC_OIDC_CLIENT_ID ?? 'aerie-ui',
+    redirect_uri: redirectUri,
+    code_challenge: challenge,
+    code_challenge_method: 'S256',
+    scope: 'openid',
+  });
+
+  throw redirect(302, `${authorizationEndpoint}?${params.toString()}`);
+};

--- a/src/routes/auth/callback/+server.ts
+++ b/src/routes/auth/callback/+server.ts
@@ -1,0 +1,62 @@
+import { base } from '$app/paths';
+import { env as privateEnv } from '$env/dynamic/private';
+import { env } from '$env/dynamic/public';
+import type { RequestHandler } from '@sveltejs/kit';
+import { redirect } from '@sveltejs/kit';
+import type { CookieSerializeOptions } from 'cookie';
+import { computeRolesFromJWT } from '../../../utilities/auth';
+import type { BaseUser } from '../../../types/app';
+
+export const GET: RequestHandler = async ({ cookies, url }) => {
+  const code = url.searchParams.get('code');
+  const verifier = cookies.get('pkceVerifier');
+
+  if (!code || !verifier) {
+    return new Response('Invalid OAuth response', { status: 400 });
+  }
+
+  const tokenResp = await fetch(`${env.PUBLIC_IDENTITY_PROVIDER_URL}/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'authorization_code',
+      client_id: env.PUBLIC_OIDC_CLIENT_ID ?? 'aerie-ui',
+      code,
+      redirect_uri: `${privateEnv.ORIGIN}${base}/auth/callback`,
+      code_verifier: verifier,
+    }),
+  });
+
+  if (!tokenResp.ok) {
+    return new Response('Authentication failed', { status: 401 });
+  }
+
+  const data = await tokenResp.json();
+  const token: string | undefined = data.id_token || data.access_token;
+  const userId = data.user_id ?? '';
+
+  if (!token) {
+    return new Response('Authentication failed', { status: 401 });
+  }
+
+  const baseUser: BaseUser = { id: userId, token };
+  const roles = await computeRolesFromJWT(baseUser, null);
+
+  if (!roles) {
+    return new Response('Unauthorized', { status: 403 });
+  }
+
+  const userStr = JSON.stringify(baseUser);
+  const userCookie = Buffer.from(userStr).toString('base64');
+  const cookieOpts: CookieSerializeOptions & { path: string } = {
+    httpOnly: false,
+    path: `${base}/`,
+    sameSite: 'none',
+  };
+
+  cookies.set('user', userCookie, cookieOpts);
+  cookies.set('activeRole', roles.defaultRole, cookieOpts);
+  cookies.delete('pkceVerifier', { path: `${base}/` });
+
+  throw redirect(302, `${base}/plans`);
+};

--- a/src/utilities/auth.ts
+++ b/src/utilities/auth.ts
@@ -1,0 +1,68 @@
+import { jwtDecode } from 'jwt-decode';
+import { randomBytes, createHash } from 'crypto';
+import type { BaseUser, ParsedUserToken, User } from '../types/app';
+import effects from './effects';
+
+export function generateCodeVerifier(): string {
+  return base64Url(randomBytes(32));
+}
+
+export function generateCodeChallenge(verifier: string): string {
+  return base64Url(createHash('sha256').update(verifier).digest());
+}
+
+function base64Url(buffer: Buffer): string {
+  return buffer
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/g, '');
+}
+
+export async function computeRolesFromJWT(
+  baseUser: BaseUser,
+  activeRole: string | null,
+): Promise<User | null> {
+  const { success } = await effects.session(baseUser);
+  if (!success) {
+    return null;
+  }
+
+  const decodedToken: ParsedUserToken = jwtDecode(baseUser.token);
+
+  const allowedRoles =
+    decodedToken['https://hasura.io/jwt/claims']['x-hasura-allowed-roles'];
+  const defaultRole =
+    decodedToken['https://hasura.io/jwt/claims']['x-hasura-default-role'];
+
+  const user: User = {
+    ...baseUser,
+    activeRole: activeRole ?? defaultRole,
+    allowedRoles,
+    defaultRole,
+    permissibleQueries: null,
+    rolePermissions: null,
+  };
+  const permissibleQueries = await effects.getUserQueries(user);
+  const rolePermissions = await effects.getRolePermissions(user);
+  return {
+    ...user,
+    permissibleQueries,
+    rolePermissions,
+  };
+}
+
+export async function computeRolesFromCookies(
+  userCookie: string | null,
+  activeRoleCookie: string | null,
+): Promise<User | null> {
+  const userBuffer = Buffer.from(userCookie ?? '', 'base64');
+  const userStr = userBuffer.toString('utf-8');
+
+  try {
+    const baseUser: BaseUser = JSON.parse(userStr);
+    return computeRolesFromJWT(baseUser, activeRoleCookie);
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- implement PKCE helpers and role utilities
- add authorize and callback routes for OAuth
- support identity provider login in `hooks.server`
- document new environment variables
- include defaults in `.env`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68518bb1e39c832cbffe7256879dd4b6